### PR TITLE
Removing label next the first step

### DIFF
--- a/src/components/play/PlayUI.js
+++ b/src/components/play/PlayUI.js
@@ -640,7 +640,7 @@ class PlayUI extends Component {
         if (layer.createdBy !== this.props.user.id) {
             layerLabelString = ""
         }
-        layerGraphic.layerLabel = this.container.plain(layerLabelString)
+        // hiding label = layerGraphic.layerLabel = this.container.plain(layerLabelString)
         layerGraphic.firstStep = null;
         for (let step of layer.steps) {
             const x = Math.round(layerDiameter / 2 + radius * Math.cos(angle) - stepDiameter / 2) + xOffset;


### PR DESCRIPTION
Commented out single line to hide the label next to the 1st step of each round 

![CleanShot 2024-07-21 at 15 13 30@2x](https://github.com/user-attachments/assets/2c15a8b7-ecd1-42a2-95b8-b82ea446c417)
